### PR TITLE
Troubleshooting exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,11 @@ Examples to implement OCR(Optical Character Recognition) using tesseract using P
   ```
   pip install wand
   ```
+
+## Troubleshooting
+- In case you encounter an exception `wand.exceptions.PolicyError`, you can try the following command to change the policy in `/etc/ImageMagick-6/policy.xml` for PDFs to `read`:
+    - On Ubuntu
+    ```
+    sudo sed -i 's,<policy domain="coder" rights="none" pattern="PDF" />,<policy domain="coder" rights="read" pattern="PDF" />,g' /etc/ImageMagick-6/policy.xml
+    ```
+    - This command modifies the policy file for ImageMagick, allowing it to read PDF files without raising a `wand.exceptions.PolicyError`.


### PR DESCRIPTION
## Pull Request Description

### Summary
This pull request adds troubleshooting information to the README file to address the issue of encountering the `wand.exceptions.PolicyError` exception. It provides instructions on how to modify the ImageMagick policy file to allow reading PDF files without raising the exception.

### Changes Made
- Added a new section titled "Troubleshooting" to the README file.
- Included instructions and a command to modify the policy in `/etc/ImageMagick-6/policy.xml` for PDFs to `read`.

### Testing Done
- Verified the provided command on my local environment to ensure it modifies the policy file correctly.
- Tested the README file rendering to confirm the new section is displayed correctly.


Thank you for considering this pull request. I look forward to your feedback and merging these changes into the main repository.